### PR TITLE
ci: add path filter to deploy workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,14 @@ name: Build and deploy
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'public/**'
+      - 'index.html'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig*.json'
+      - 'vite.config.js'
 
 env:
   VITE_API_URL: ${{ secrets.API_URL }}


### PR DESCRIPTION
## Summary
- Add `paths` filter to deploy workflow so it only triggers when app-relevant files change
- Paths that trigger deploy: `src/**`, `public/**`, `index.html`, `package.json`, `package-lock.json`, `tsconfig*.json`, `vite.config.js`
- Changes to `.github/`, `*.md`, `.prettierrc`, `.eslintrc.*`, etc. no longer trigger a deploy

## Test plan
- [ ] Merge this PR and confirm the deploy workflow does **not** run (since only the workflow file changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)